### PR TITLE
Reduce vendor-chunk.js production distribution size 

### DIFF
--- a/web_ui/package-lock.json
+++ b/web_ui/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "web_ui",
       "version": "0.1.0",
       "dependencies": {
         "axios": "^0.21.1",
@@ -13281,6 +13282,7 @@
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/svgo/-/svgo-1.3.2.tgz",
       "integrity": "sha512-yhy/sQYxR5BkC98CY7o31VGsg014AKLEPxdfhora76l36hD9Rdy5NZA/Ocn6yayNPgSamYdtX2rFJdcv07AYVw==",
+      "deprecated": "This SVGO version is no longer supported. Upgrade to v2.x.x.",
       "dev": true,
       "dependencies": {
         "chalk": "^2.4.1",
@@ -14405,15 +14407,6 @@
         "chalk": "^4.1.0",
         "hash-sum": "^2.0.0",
         "loader-utils": "^2.0.0"
-      },
-      "peerDependencies": {
-        "@vue/compiler-sfc": "^3.0.8",
-        "webpack": "^4.1.0 || ^5.0.0-0"
-      },
-      "peerDependenciesMeta": {
-        "@vue/compiler-sfc": {
-          "optional": true
-        }
       }
     },
     "node_modules/vue-loader-v16/node_modules/ansi-styles": {

--- a/web_ui/src/main.js
+++ b/web_ui/src/main.js
@@ -1,29 +1,28 @@
 import Vue from "vue";
 import App from "./App.vue";
 import {
-    TooltipPlugin,
-    FormPlugin,
-    LayoutPlugin,
-    ButtonPlugin,
-    FormInputPlugin,
-    FormCheckboxPlugin,
-    FormRadioPlugin,
-    FormGroupPlugin
-} from "bootstrap-vue"
+  TooltipPlugin,
+  FormPlugin,
+  LayoutPlugin,
+  ButtonPlugin,
+  FormInputPlugin,
+  FormCheckboxPlugin,
+  FormRadioPlugin,
+  FormGroupPlugin,
+} from "bootstrap-vue";
 import "bootstrap/dist/css/bootstrap.css";
 import "bootstrap-vue/dist/bootstrap-vue.css";
 import router from "./router";
 
 // For tree shaking purposes
-Vue.use(TooltipPlugin)
-Vue.use(FormPlugin)
-Vue.use(LayoutPlugin)
-Vue.use(ButtonPlugin)
-Vue.use(FormCheckboxPlugin)
-Vue.use(FormInputPlugin)
-Vue.use(FormGroupPlugin)
-Vue.use(FormRadioPlugin)
-
+Vue.use(TooltipPlugin);
+Vue.use(FormPlugin);
+Vue.use(LayoutPlugin);
+Vue.use(ButtonPlugin);
+Vue.use(FormCheckboxPlugin);
+Vue.use(FormInputPlugin);
+Vue.use(FormGroupPlugin);
+Vue.use(FormRadioPlugin);
 
 Vue.config.productionTip = false;
 

--- a/web_ui/src/main.js
+++ b/web_ui/src/main.js
@@ -1,11 +1,29 @@
 import Vue from "vue";
 import App from "./App.vue";
-import BootstrapVue from "bootstrap-vue";
+import {
+    TooltipPlugin,
+    FormPlugin,
+    LayoutPlugin,
+    ButtonPlugin,
+    FormInputPlugin,
+    FormCheckboxPlugin,
+    FormRadioPlugin,
+    FormGroupPlugin
+} from "bootstrap-vue"
 import "bootstrap/dist/css/bootstrap.css";
 import "bootstrap-vue/dist/bootstrap-vue.css";
 import router from "./router";
 
-Vue.use(BootstrapVue);
+// For tree shaking purposes
+Vue.use(TooltipPlugin)
+Vue.use(FormPlugin)
+Vue.use(LayoutPlugin)
+Vue.use(ButtonPlugin)
+Vue.use(FormCheckboxPlugin)
+Vue.use(FormInputPlugin)
+Vue.use(FormGroupPlugin)
+Vue.use(FormRadioPlugin)
+
 
 Vue.config.productionTip = false;
 


### PR DESCRIPTION
Explicitly install the BootstrapVue plugins of used components so that webpack can do [tree shaking](https://bootstrap-vue.org/docs).

Known plugins added are:

-  TooltipPlugin,
-   FormPlugin
-   LayoutPlugin
-   ButtonPlugin
-   FormInputPlugin
-   FormCheckboxPlugin
-   FormRadioPlugin
-   FormGroupPlugin

Tested by opening GUI in browser and looked in console for unknown errors.