### PR TITLE
Increased MQTT buffer size for Smoke X4

### DIFF
--- a/main/app_mqtt.c
+++ b/main/app_mqtt.c
@@ -8,7 +8,7 @@
 #include "smoke_x.h"
 
 #define NVS_NAMESPACE "mqtt_config"
-#define MQTT_BUF_SIZE 512
+#define MQTT_BUF_SIZE 1024
 
 #define BOOL_TO_STR(b) b ? "ON" : "OFF"
 


### PR DESCRIPTION
Increased MQTT message buffer size from 512->1024 to prevent truncation when using Smoke X4.

Before (truncated to 512 characters):
```json
{"probe_1_attached":"ON","probe_1_alarm":"OFF","probe_1_temp":68.5,"probe_1_max":200,"probe_1_min":32,"billows_target":"offline","probe_2_attached":"ON","probe_2_alarm":"OFF","probe_2_temp":69.5,"probe_2_max":200,"probe_2_min":32,"billows_target":"offline","probe_3_attached":"ON","probe_3_alarm":"OFF","probe_3_temp":68.8,"probe_3_max":160,"probe_3_min":32,"billows_target":"offline","probe_4_attached":"OFF","probe_4_alarm":"offline","probe_4_temp":"offline","probe_4_max":"offline","probe_4_min":"offline",
```

After (533 characters):
```json
{"probe_1_attached":"ON","probe_1_alarm":"OFF","probe_1_temp":68.4,"probe_1_max":200,"probe_1_min":32,"billows_target":"offline","probe_2_attached":"ON","probe_2_alarm":"OFF","probe_2_temp":69.5,"probe_2_max":200,"probe_2_min":32,"billows_target":"offline","probe_3_attached":"ON","probe_3_alarm":"OFF","probe_3_temp":68.8,"probe_3_max":160,"probe_3_min":32,"billows_target":"offline","probe_4_attached":"OFF","probe_4_alarm":"offline","probe_4_temp":"offline","probe_4_max":"offline","probe_4_min":"offline","billows_attached":"ON"}
```