### PR TITLE
Use HTTPS to allow others to clone submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,4 +3,4 @@
 	url = https://github.com/nopnop2002/esp-idf-sx127x.git
 [submodule "esp-idf-sx126x"]
 	path = esp-idf-sx126x
-	url = git@github.com:nopnop2002/esp-idf-sx126x.git
+	url = https://github.com/nopnop2002/esp-idf-sx126x.git


### PR DESCRIPTION
Point to the HTTPS version so, when cloning, people do not get SSH errors.