### PR TITLE
Document backwards compatibility with Cmake 3.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,10 @@ An ESP32 with attached Semtech LoRa transceiver operating in the 915 MHz ISM ban
   $ git clone --recurse-submodules git@github.com:G-Two/smoke-x-receiver.git
   $ cd smoke-x-receiver
   ```
+- If you have Cmake version 4 or later, you may need to enable backwards compatibility with Cmake 3.5.
+  ```bash
+  $ export CMAKE_POLICY_VERSION_MINIMUM=3.5
+  ```
 
 ### Configure
 


### PR DESCRIPTION
ESP-IDF 4.4 uses Cmake 3.5, which current versions of Cmake will error out on. It's possible to get around this by setting an environment variable, which I added to the readme.