### PR TITLE
Add Makefile build workflow for Heltec V2/V3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 **/*
 
 !clang-format
-!mock_www.sh
+!mock_web_ui.sh
 !pre-commit-config.yaml
 !CMakeLists.txt
 !LICENSE
@@ -11,6 +11,7 @@
 !README.md
 !partitions.csv
 !sdkconfig.defaults
+!sdkconfig.defaults.*
 
 # ESP32 Code
 !/main

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,257 @@
+# Smoke X Receiver
+#
+# Prerequisites:
+#   brew bundle        # python@3.11, cmake, ninja (see Brewfile)
+#   make check-python  # verify a supported Python is available
+#   make init-idf      # verify ESP-IDF (firmware targets auto-source export.sh)
+#   make setup
+#
+# Options:
+#   PORT=/dev/cu.usbserial-XXXX  Serial port for flash/monitor (auto-detect if omitted)
+#   IDF_EXPORT=/path/to/esp-idf/export.sh  Override ESP-IDF location
+
+.DEFAULT_GOAL := help
+
+IDF_PY ?= idf.py
+PORT ?=
+CMAKE_POLICY ?= CMAKE_POLICY_VERSION_MINIMUM=3.5
+
+# ESP-IDF v4.4 supports Python 3.8–3.11. Prefer Homebrew python@3.11 shims, then
+# versioned python3.x binaries already on PATH.
+IDF_PYTHON_DIR := $(shell \
+	python_ok() { "$$1" -c 'import sys; sys.exit(0 if (3,8) <= sys.version_info[:2] <= (3,11) else 1)' 2>/dev/null; }; \
+	for dir in \
+		/opt/homebrew/opt/python@3.11/libexec/bin \
+		/usr/local/opt/python@3.11/libexec/bin \
+		$$(brew --prefix 2>/dev/null)/opt/python@3.11/libexec/bin; do \
+		test -n "$$dir" || continue; \
+		test -x "$$dir/python3" && python_ok "$$dir/python3" && { echo "$$dir"; exit 0; }; \
+		test -x "$$dir/python" && python_ok "$$dir/python" && { echo "$$dir"; exit 0; }; \
+	done; \
+	for cmd in python3.11 python3.10 python3.9 python3.8 python3 python; do \
+		path=$$(command -v $$cmd 2>/dev/null) || continue; \
+		python_ok "$$path" && { dirname "$$path"; exit 0; }; \
+	done \
+)
+IDF_PYTHON_PATH := $(if $(IDF_PYTHON_DIR),PATH="$(IDF_PYTHON_DIR):$$PATH",)
+
+ifdef IDF_PATH
+IDF_EXPORT ?= $(IDF_PATH)/export.sh
+else
+IDF_EXPORT ?= $(HOME)/esp/esp-idf/export.sh
+endif
+
+COMMON_DEFAULTS := sdkconfig.defaults
+V2_DEFAULTS := $(COMMON_DEFAULTS);sdkconfig.defaults.heltec-v2
+V3_DEFAULTS := $(COMMON_DEFAULTS);sdkconfig.defaults.heltec-v3
+
+V2_BUILD := build/heltec-v2
+V3_BUILD := build/heltec-v3
+
+PORT_ARG := $(if $(PORT),-p $(PORT),)
+
+define source_idf
+	$(IDF_PYTHON_PATH) . "$(IDF_EXPORT)"
+endef
+
+# check-python: Verify ESP-IDF-compatible Python (3.8–3.11) is available
+check-python:
+	@if [ -n "$(IDF_PYTHON_DIR)" ]; then \
+		if [ -x "$(IDF_PYTHON_DIR)/python3" ]; then \
+			py="$(IDF_PYTHON_DIR)/python3"; \
+		else \
+			py="$(IDF_PYTHON_DIR)/python"; \
+		fi; \
+		echo "ESP-IDF Python: $$($$py --version) ($$py)"; \
+	else \
+		echo ""; \
+		echo "Error: No supported Python found (ESP-IDF v4.4 needs 3.8–3.11)."; \
+		echo ""; \
+		echo "Install dependencies and retry:"; \
+		echo "  brew bundle"; \
+		echo "  make check-python"; \
+		echo ""; \
+		current=$$(command -v python3 2>/dev/null); \
+		if [ -n "$$current" ]; then \
+			echo "Current python3: $$($$current --version) ($$current)"; \
+		else \
+			echo "Current python3: not found"; \
+		fi; \
+		exit 1; \
+	fi
+
+# check-idf: Verify ESP-IDF export script exists and idf.py runs (internal)
+check-idf: check-python
+	@test -f "$(IDF_EXPORT)" || { \
+		echo ""; \
+		echo "Error: ESP-IDF export script not found at:"; \
+		echo "  $(IDF_EXPORT)"; \
+		echo ""; \
+		echo "Install ESP-IDF v4.4, then retry or set IDF_EXPORT:"; \
+		echo "  https://docs.espressif.com/projects/esp-idf/en/release-v4.4/esp32/get-started/"; \
+		echo "  make init-idf IDF_EXPORT=/path/to/esp-idf/export.sh"; \
+		echo ""; \
+		exit 1; \
+	}
+	@$(source_idf) && command -v $(IDF_PY) >/dev/null || { \
+		echo ""; \
+		echo "Error: sourced $(IDF_EXPORT) but idf.py is still unavailable."; \
+		echo "Re-run ESP-IDF install.sh with a supported Python, e.g.:"; \
+		echo "  PATH=\"$(IDF_PYTHON_DIR):\$$PATH\" $(dir $(IDF_EXPORT))install.sh"; \
+		echo ""; \
+		exit 1; \
+	}
+
+define idf
+	$(IDF_PYTHON_PATH) . "$(IDF_EXPORT)" && $(CMAKE_POLICY) SDKCONFIG_DEFAULTS="$(1)" $(IDF_PY) -B $(2) $(3)
+endef
+
+.PHONY: help check-python check-idf init-idf \
+	build-heltec-v2 build-heltec-v3 \
+	flash-heltec-v2 flash-heltec-v3 \
+	flash-monitor-heltec-v2 flash-monitor-heltec-v3 \
+	install-heltec-v2 install-heltec-v3 \
+	monitor-heltec-v2 monitor-heltec-v3 \
+	menuconfig-heltec-v2 menuconfig-heltec-v3 \
+	clean clean-heltec-v2 clean-heltec-v3 \
+	heltec-v2 heltec-v3 \
+	submodules setup \
+	mock-web-ui build-web-ui web-ui-install web-ui-lint web-ui-format clean-web-ui
+
+# help: Show available targets and usage
+help:
+	@echo "Smoke X Receiver"
+	@echo ""
+	@awk '\
+		/^# --- .+ ---$$/ { \
+			if (sections++) print ""; \
+			gsub(/^# --- | ---$$/, "", $$0); \
+			printf "%s:\n", $$0; \
+			next \
+		} \
+		/^# [a-zA-Z0-9_.-]+: / { \
+			if ($$0 ~ /^# help: / || $$0 ~ /^# check-idf: /) next; \
+			target = $$0; \
+			sub(/^# /, "", target); \
+			sub(/: .*$$/, "", target); \
+			desc = $$0; \
+			sub(/^# [a-zA-Z0-9_.-]+: /, "", desc); \
+			printf "  \033[36m%s\033[0m   %s\n", target, desc; \
+			next \
+		}' $(MAKEFILE_LIST)
+	@echo ""
+	@echo "Firmware targets auto-source: $(IDF_EXPORT)"
+	@echo "For interactive shells: source \"$(IDF_EXPORT)\""
+
+# --- Project setup ---
+
+# init-idf: Verify ESP-IDF is installed and print idf.py version
+init-idf: check-idf
+	@echo "ESP-IDF ready: $(IDF_EXPORT)"
+	@$(source_idf) && $(IDF_PY) --version
+
+# --- Heltec install ---
+
+$(V2_BUILD)/.target-esp32: check-idf
+	$(call idf,$(V2_DEFAULTS),$(V2_BUILD),set-target esp32)
+	@touch $@
+
+# build-heltec-v2: Build firmware for Heltec WiFi LoRa 32 V2 (ESP32, SX1276)
+build-heltec-v2: $(V2_BUILD)/.target-esp32
+	$(call idf,$(V2_DEFAULTS),$(V2_BUILD),build)
+
+# flash-heltec-v2: Build and flash Heltec WiFi LoRa 32 V2
+flash-heltec-v2: $(V2_BUILD)/.target-esp32
+	$(call idf,$(V2_DEFAULTS),$(V2_BUILD),build flash $(PORT_ARG))
+
+# install-heltec-v2: Build and flash Heltec WiFi LoRa 32 V2
+install-heltec-v2: flash-heltec-v2
+
+# flash-monitor-heltec-v2: Build, flash, and open serial monitor (V2)
+flash-monitor-heltec-v2: $(V2_BUILD)/.target-esp32
+	$(call idf,$(V2_DEFAULTS),$(V2_BUILD),build flash monitor $(PORT_ARG))
+
+# monitor-heltec-v2: Open serial monitor for V2 build
+monitor-heltec-v2: check-idf
+	$(call idf,$(V2_DEFAULTS),$(V2_BUILD),monitor $(PORT_ARG))
+
+# menuconfig-heltec-v2: Open menuconfig for V2
+menuconfig-heltec-v2: $(V2_BUILD)/.target-esp32
+	$(call idf,$(V2_DEFAULTS),$(V2_BUILD),menuconfig)
+
+# clean-heltec-v2: Remove V2 build directory
+clean-heltec-v2:
+	rm -rf $(V2_BUILD)
+
+heltec-v2: install-heltec-v2
+
+$(V3_BUILD)/.target-esp32s3: check-idf
+	$(call idf,$(V3_DEFAULTS),$(V3_BUILD),set-target esp32s3)
+	@touch $@
+
+# build-heltec-v3: Build firmware for Heltec WiFi LoRa 32 V3 (ESP32-S3, SX1262)
+build-heltec-v3: $(V3_BUILD)/.target-esp32s3
+	$(call idf,$(V3_DEFAULTS),$(V3_BUILD),build)
+
+# flash-heltec-v3: Build and flash Heltec WiFi LoRa 32 V3
+flash-heltec-v3: $(V3_BUILD)/.target-esp32s3
+	$(call idf,$(V3_DEFAULTS),$(V3_BUILD),build flash $(PORT_ARG))
+
+# install-heltec-v3: Build and flash Heltec WiFi LoRa 32 V3
+install-heltec-v3: flash-heltec-v3
+
+# flash-monitor-heltec-v3: Build, flash, and open serial monitor (V3)
+flash-monitor-heltec-v3: $(V3_BUILD)/.target-esp32s3
+	$(call idf,$(V3_DEFAULTS),$(V3_BUILD),build flash monitor $(PORT_ARG))
+
+# monitor-heltec-v3: Open serial monitor for V3 build
+monitor-heltec-v3: check-idf
+	$(call idf,$(V3_DEFAULTS),$(V3_BUILD),monitor $(PORT_ARG))
+
+# menuconfig-heltec-v3: Open menuconfig for V3
+menuconfig-heltec-v3: $(V3_BUILD)/.target-esp32s3
+	$(call idf,$(V3_DEFAULTS),$(V3_BUILD),menuconfig)
+
+# clean-heltec-v3: Remove V3 build directory
+clean-heltec-v3:
+	rm -rf $(V3_BUILD)
+
+heltec-v3: install-heltec-v3
+
+# --- Web UI ---
+
+# mock-web-ui: Run web UI dev server with mocked API (./mock_web_ui.sh)
+mock-web-ui:
+	./mock_web_ui.sh
+
+# build-web-ui: Build production web assets for ESP32 flash
+build-web-ui:
+	./web_ui/build.sh web_ui
+
+# web-ui-install: npm install in web_ui/
+web-ui-install:
+	npm install --prefix web_ui
+
+# web-ui-lint: Lint web UI sources
+web-ui-lint:
+	npm run lint --prefix web_ui
+
+# web-ui-format: Format web UI sources with Prettier
+web-ui-format:
+	npm run format --prefix web_ui
+
+# clean-web-ui: Remove web_ui/node_modules and web_ui/dist
+clean-web-ui:
+	rm -rf web_ui/node_modules web_ui/dist
+
+# submodules: Initialize and update git submodules
+submodules:
+	git submodule update --init --recursive
+
+# setup: Initialize submodules and install web UI dependencies
+setup: submodules web-ui-install
+
+# --- Clean ---
+
+# clean: Remove all board build directories
+clean: clean-heltec-v2 clean-heltec-v3

--- a/README.md
+++ b/README.md
@@ -81,28 +81,50 @@ An ESP32 with attached Semtech LoRa transceiver operating in the 915 MHz ISM ban
 
 ### Software
 
-- ESP-IDF SDK v4.4 [installation instructions](https://docs.espressif.com/projects/esp-idf/en/release-v4.4/esp32/get-started/index.html)
+- [ESP-IDF SDK v4.4](https://docs.espressif.com/projects/esp-idf/en/release-v4.4/esp32/get-started/index.html) (provides `idf.py` and the ESP32 toolchain)
 - Node.js and npm (to build the web UI assets)
 
 ---
 
 ## Build
 
+### Install ESP-IDF
+
+`idf.py` is not installed separately — it ships with the ESP-IDF SDK. This project targets **ESP-IDF v4.4**.
+
+On macOS, a typical first-time install looks like:
+
+```bash
+mkdir -p ~/esp
+cd ~/esp
+git clone -b release/v4.4 --recursive https://github.com/espressif/esp-idf.git
+cd esp-idf
+./install.sh esp32,esp32s3
+```
+
+See the official guide for other platforms and install options:
+https://docs.espressif.com/projects/esp-idf/en/release-v4.4/esp32/get-started/index.html
+
 ### Prepare Environment
 
-- Activate ESP-IDF
-  ```bash
-  $ source /path/to/esp-idf/export.sh
-  ```
-- Clone this repo (including its submodules) and enter the directory.
-  ```bash
-  $ git clone --recurse-submodules git@github.com:G-Two/smoke-x-receiver.git
-  $ cd smoke-x-receiver
-  ```
-- If you have Cmake version 4 or later, you may need to enable backwards compatibility with Cmake 3.5.
-  ```bash
-  $ export CMAKE_POLICY_VERSION_MINIMUM=3.5
-  ```
+Every new terminal session must activate ESP-IDF before using `idf.py` directly. Firmware `make` targets source it automatically.
+
+```bash
+source ~/esp/esp-idf/export.sh   # adjust path if you cloned elsewhere
+# or verify via make:
+make init-idf
+idf.py --version
+```
+
+Then clone this repo (including its submodules) and install web UI dependencies:
+
+```bash
+git clone --recurse-submodules git@github.com:G-Two/smoke-x-receiver.git
+cd smoke-x-receiver
+make setup
+```
+
+If you have Cmake version 4 or later, you may need to enable backwards compatibility with Cmake 3.5 (the Makefile sets this automatically for firmware targets).
 
 ### Configure
 
@@ -125,11 +147,19 @@ An ESP32 with attached Semtech LoRa transceiver operating in the 915 MHz ISM ban
 
 ### Build and Flash
 
-- Connect your ESP32 to your computer and run:
-  ```bash
-  $ idf.py set-target esp32s3 # If using a Heltec WiFi LoRa 32 v3, otherwise set target as appropriate to your hardware
-  $ idf.py flash
-  ```
+Connect your ESP32 and run one of:
+
+```bash
+make install-heltec-v3   # Heltec WiFi LoRa 32 V3 (default)
+make install-heltec-v2   # Heltec WiFi LoRa 32 V2
+```
+
+Or manually:
+
+```bash
+idf.py set-target esp32s3   # use esp32 for Heltec V2
+idf.py flash
+```
 
 The application and web assets will be built and written to the ESP32 flash.
 

--- a/sdkconfig.defaults.heltec-v2
+++ b/sdkconfig.defaults.heltec-v2
@@ -1,0 +1,14 @@
+# Heltec WiFi LoRa 32 V2 (ESP32 + SX1276)
+# https://heltec.org/project/wifi-lora-32/
+
+CONFIG_IDF_TARGET="esp32"
+
+# CONFIG_SX126x is not set
+CONFIG_SX127x=y
+
+# Heltec WiFi LoRa 32 v2 SPI pin assignments (see README)
+CONFIG_CS_GPIO=18
+CONFIG_RST_GPIO=14
+CONFIG_MISO_GPIO=19
+CONFIG_MOSI_GPIO=27
+CONFIG_SCK_GPIO=5

--- a/sdkconfig.defaults.heltec-v3
+++ b/sdkconfig.defaults.heltec-v3
@@ -1,0 +1,15 @@
+# Heltec WiFi LoRa 32 V3 (ESP32-S3 + SX1262)
+# https://heltec.org/project/wifi-lora-32-v3/
+
+CONFIG_IDF_TARGET="esp32s3"
+
+CONFIG_SX126x=y
+# CONFIG_SX127x is not set
+
+# Heltec WiFi LoRa 32 v3 SPI pin assignments (Kconfig defaults)
+CONFIG_NSS_GPIO=8
+CONFIG_RST_GPIO=12
+CONFIG_MISO_GPIO=11
+CONFIG_MOSI_GPIO=10
+CONFIG_SCLK_GPIO=9
+CONFIG_BUSY_GPIO=13


### PR DESCRIPTION
## Summary
- Add a root `Makefile` with Heltec V2/V3 firmware targets (`build`, `flash`, `install`, `monitor`, `menuconfig`) that auto-source ESP-IDF and apply board-specific `sdkconfig.defaults`
- Add `sdkconfig.defaults.heltec-v2` and `sdkconfig.defaults.heltec-v3` with LoRa modem and GPIO defaults for each board
- Update README build/flash docs to use the new make workflow and document ESP-IDF v4.4 setup
- Fix `.gitignore` to track `mock_web_ui.sh` and per-board sdkconfig default files

## Test plan
- [ ] `make check-python` succeeds with ESP-IDF-compatible Python
- [ ] `make init-idf` finds ESP-IDF and prints `idf.py --version`
- [ ] `make setup` initializes submodules and installs web UI deps
- [ ] `make build-heltec-v3` completes on a machine with ESP-IDF v4.4 installed
- [ ] `make install-heltec-v3 PORT=...` flashes a Heltec V3 board


Made with [Cursor](https://cursor.com)